### PR TITLE
Do not try to read remote CSS files imported with url(..)

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,10 @@ function makeVarMap(filename) {
     }
   }
 
+  function isUrl(string) {
+    return /(https?:)?\/\//.test(string);
+  }
+
   function process(fn) {
     var style = postcss().process(fs.readFileSync(fn, 'utf8'));
 
@@ -95,7 +99,11 @@ function makeVarMap(filename) {
       if (atRule.name !== 'import')
         return;
 
-      var stripped = stripQuotes(atRule.params);
+      var stripped = stripQuotes(unwrapUrl(atRule.params));
+
+      if(isUrl(stripped)) {
+        return;
+      }
 
       process(resolveImport(stripped, dirname(fn)));
     });


### PR DESCRIPTION
When creating a var map from a CSS file which contains a
`@import url('https://google.com/fonts.css');` statement, the `process`
method will try to read this file too.
By checking if we are encountering a remote url, we can early abort
to leave remote url imports untouched.
